### PR TITLE
Junqo v0.5.5

### DIFF
--- a/junqo_back/src/applications/applications.service.ts
+++ b/junqo_back/src/applications/applications.service.ts
@@ -28,6 +28,8 @@ import { UserType } from '../users/dto/user-type.enum';
 import { ConversationsService } from '../conversations/conversations.service';
 import { CreateConversationDTO } from '../conversations/dto/conversation.dto';
 import { MessagesService } from '../messages/messages.service';
+import { MAX_CONVERSATION_TITLE_LENGTH } from '../shared/user-validation-constants';
+import { truncateString } from '../shared/string-utils';
 import { StudentProfilesService } from '../student-profiles/student-profiles.service';
 
 @Injectable()
@@ -521,10 +523,19 @@ export class ApplicationsService {
       const createConversationDto: CreateConversationDTO = {
         participantsIds: [application.studentId, application.companyId],
         participantTitles: {
-          [application.studentId]: `${offerTitle} - ${companyName}`,
-          [application.companyId]: `${offerTitle} - ${studentName}`,
+          [application.studentId]: truncateString(
+            `${offerTitle} - ${companyName}`,
+            MAX_CONVERSATION_TITLE_LENGTH,
+          ),
+          [application.companyId]: truncateString(
+            `${offerTitle} - ${studentName}`,
+            MAX_CONVERSATION_TITLE_LENGTH,
+          ),
         },
-        title: `Application Discussion - ${offerTitle || 'Job Application'}`,
+        title: truncateString(
+          `Application Discussion - ${offerTitle}`,
+          MAX_CONVERSATION_TITLE_LENGTH,
+        ),
         offerId: application.offerId,
         applicationId: application.id,
       };

--- a/junqo_back/src/conversations/conversations.service.ts
+++ b/junqo_back/src/conversations/conversations.service.ts
@@ -83,6 +83,7 @@ export class ConversationsService {
     const conversationData: CreateConversationDTO = {
       participantsIds: participantsIds,
       title: createConversationDto.title,
+      participantTitles: createConversationDto.participantTitles,
       offerId: createConversationDto.offerId,
       applicationId: createConversationDto.applicationId,
     };

--- a/junqo_back/src/conversations/dto/conversation.dto.ts
+++ b/junqo_back/src/conversations/dto/conversation.dto.ts
@@ -11,6 +11,7 @@ import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose, Type } from 'class-transformer';
 import { MessageDTO } from '../../messages/dto/message.dto';
 import { MAX_CONVERSATION_TITLE_LENGTH } from '../../shared/user-validation-constants';
+import { RecordStringMaxLength } from '../../shared/validators/record-string-max-length.validator';
 
 // Conversation retrieved from database
 export class ConversationDTO {
@@ -175,6 +176,9 @@ export class CreateConversationDTO {
   })
   @Expose()
   @IsOptional()
+  @RecordStringMaxLength(MAX_CONVERSATION_TITLE_LENGTH, {
+    message: `Each participant title must be ${MAX_CONVERSATION_TITLE_LENGTH} characters or less`,
+  })
   participantTitles?: Record<string, string>;
 }
 

--- a/junqo_back/src/shared/string-utils.spec.ts
+++ b/junqo_back/src/shared/string-utils.spec.ts
@@ -1,0 +1,117 @@
+import { truncateString } from './string-utils';
+
+describe('truncateString', () => {
+  describe('normal truncation', () => {
+    it('should truncate a long string and append default suffix', () => {
+      const result = truncateString('Hello, World!', 10);
+      expect(result).toBe('Hello, ...');
+      expect(result.length).toBe(10);
+    });
+
+    it('should truncate with custom suffix', () => {
+      const result = truncateString('Hello, World!', 10, '…');
+      expect(result).toBe('Hello, Wo…');
+      expect(result.length).toBe(10);
+    });
+
+    it('should truncate with longer custom suffix', () => {
+      const result = truncateString('Hello, World!', 12, ' [more]');
+      expect(result).toBe('Hello [more]');
+      expect(result.length).toBe(12);
+    });
+  });
+
+  describe('strings shorter than maxLength', () => {
+    it('should return original string when shorter than maxLength', () => {
+      const result = truncateString('Hello', 10);
+      expect(result).toBe('Hello');
+    });
+
+    it('should return original string when equal to maxLength', () => {
+      const result = truncateString('HelloWorld', 10);
+      expect(result).toBe('HelloWorld');
+    });
+
+    it('should handle empty string', () => {
+      const result = truncateString('', 10);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('edge cases with maxLength <= suffix.length', () => {
+    it('should return truncated suffix when maxLength equals suffix length and string is long', () => {
+      const result = truncateString('Hello, World!', 3);
+      expect(result).toBe('...');
+      expect(result.length).toBe(3);
+    });
+
+    it('should return original string when shorter than maxLength and maxLength equals suffix length', () => {
+      const result = truncateString('Hi', 3);
+      expect(result).toBe('Hi');
+    });
+
+    it('should return truncated suffix when maxLength is less than suffix length', () => {
+      const result = truncateString('Hello, World!', 2);
+      expect(result).toBe('..');
+      expect(result.length).toBe(2);
+    });
+
+    it('should return truncated suffix with custom suffix when maxLength is less than suffix length', () => {
+      const result = truncateString('Hello, World!', 2, '---');
+      expect(result).toBe('--');
+      expect(result.length).toBe(2);
+    });
+
+    it('should return single char when maxLength is 1 and string is long', () => {
+      const result = truncateString('Hello', 1);
+      expect(result).toBe('.');
+      expect(result.length).toBe(1);
+    });
+  });
+
+  describe('edge cases with maxLength <= 0', () => {
+    it('should return empty string when maxLength is 0', () => {
+      const result = truncateString('Hello', 0);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string when maxLength is negative', () => {
+      const result = truncateString('Hello', -5);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('edge cases with empty suffix', () => {
+    it('should truncate without suffix when suffix is empty', () => {
+      const result = truncateString('Hello, World!', 5, '');
+      expect(result).toBe('Hello');
+      expect(result.length).toBe(5);
+    });
+
+    it('should return original string when shorter than maxLength with empty suffix', () => {
+      const result = truncateString('Hi', 5, '');
+      expect(result).toBe('Hi');
+    });
+  });
+
+  describe('real-world scenario: conversation titles', () => {
+    const MAX_CONVERSATION_TITLE_LENGTH = 250;
+
+    it('should handle normal conversation title', () => {
+      const title = 'Software Engineer Position - TechCorp';
+      const result = truncateString(title, MAX_CONVERSATION_TITLE_LENGTH);
+      expect(result).toBe(title);
+    });
+
+    it('should truncate extremely long offer title', () => {
+      const longOfferTitle = 'A'.repeat(300);
+      const companyName = 'TechCorp';
+      const fullTitle = `${longOfferTitle} - ${companyName}`;
+
+      const result = truncateString(fullTitle, MAX_CONVERSATION_TITLE_LENGTH);
+
+      expect(result.length).toBe(MAX_CONVERSATION_TITLE_LENGTH);
+      expect(result.endsWith('...')).toBe(true);
+    });
+  });
+});

--- a/junqo_back/src/shared/string-utils.ts
+++ b/junqo_back/src/shared/string-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Truncates a string to a maximum length, appending a suffix if truncated.
+ *
+ * @param str - The string to truncate
+ * @param maxLength - The maximum length of the resulting string (including suffix)
+ * @param suffix - The suffix to append when truncating (default: '...')
+ * @returns The truncated string, or the original if within maxLength
+ * @throws Error if maxLength is less than or equal to suffix length
+ */
+export function truncateString(
+  str: string,
+  maxLength: number,
+  suffix: string = '...',
+): string {
+  if (maxLength <= 0) {
+    return '';
+  }
+  if (maxLength <= suffix.length) {
+    return str.length <= maxLength ? str : suffix.slice(0, maxLength);
+  }
+  if (str.length <= maxLength) {
+    return str;
+  }
+  return str.slice(0, maxLength - suffix.length) + suffix;
+}

--- a/junqo_back/src/shared/user-validation-constants.ts
+++ b/junqo_back/src/shared/user-validation-constants.ts
@@ -7,4 +7,4 @@ export const MAX_MAIL_LENGTH = 255;
 export const MIN_PASSWORD_LENGTH = 8;
 export const MAX_PASSWORD_LENGTH = 72; // bcrypt max length
 
-export const MAX_CONVERSATION_TITLE_LENGTH = 50;
+export const MAX_CONVERSATION_TITLE_LENGTH = 150;

--- a/junqo_back/src/shared/validators/record-string-max-length.validator.spec.ts
+++ b/junqo_back/src/shared/validators/record-string-max-length.validator.spec.ts
@@ -1,0 +1,108 @@
+import { validate } from 'class-validator';
+import { RecordStringMaxLength } from './record-string-max-length.validator';
+
+class TestClass {
+  @RecordStringMaxLength(10)
+  titles?: Record<string, string>;
+}
+
+describe('RecordStringMaxLength', () => {
+  describe('valid cases', () => {
+    it('should pass validation when all values are within max length', async () => {
+      const obj = new TestClass();
+      obj.titles = {
+        key1: 'short',
+        key2: 'also short',
+      };
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation when value is exactly at max length', async () => {
+      const obj = new TestClass();
+      obj.titles = {
+        key1: 'A'.repeat(10),
+      };
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation when value is null', async () => {
+      const obj = new TestClass();
+      obj.titles = null;
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation when value is undefined', async () => {
+      const obj = new TestClass();
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(0);
+    });
+
+    it('should pass validation for empty record', async () => {
+      const obj = new TestClass();
+      obj.titles = {};
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(0);
+    });
+  });
+
+  describe('invalid cases', () => {
+    it('should fail validation when a value exceeds max length', async () => {
+      const obj = new TestClass();
+      obj.titles = {
+        key1: 'short',
+        key2: 'this is way too long for the limit',
+      };
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(1);
+      expect(errors[0].property).toBe('titles');
+    });
+
+    it('should fail validation when value is not a string', async () => {
+      const obj = new TestClass();
+      obj.titles = {
+        key1: 'valid',
+        key2: 123 as unknown as string,
+      };
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(1);
+    });
+
+    it('should fail validation when value is not an object', async () => {
+      const obj = new TestClass();
+      obj.titles = 'not an object' as unknown as Record<string, string>;
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(1);
+    });
+  });
+
+  describe('custom error message', () => {
+    class TestClassWithMessage {
+      @RecordStringMaxLength(5, { message: 'Custom error message' })
+      titles?: Record<string, string>;
+    }
+
+    it('should use custom error message when provided', async () => {
+      const obj = new TestClassWithMessage();
+      obj.titles = {
+        key1: 'too long value',
+      };
+
+      const errors = await validate(obj);
+      expect(errors.length).toBe(1);
+      expect(errors[0].constraints?.recordStringMaxLength).toBe(
+        'Custom error message',
+      );
+    });
+  });
+});

--- a/junqo_back/src/shared/validators/record-string-max-length.validator.ts
+++ b/junqo_back/src/shared/validators/record-string-max-length.validator.ts
@@ -1,0 +1,47 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+
+/**
+ * Custom validator that validates max length of string values in a Record<string, string>
+ * @param maxLength - Maximum allowed length for each string value
+ * @param validationOptions - Optional validation options
+ */
+export function RecordStringMaxLength(
+  maxLength: number,
+  validationOptions?: ValidationOptions,
+) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'recordStringMaxLength',
+      target: object.constructor,
+      propertyName: propertyName,
+      constraints: [maxLength],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments) {
+          if (value === null || value === undefined) {
+            return true; // Let @IsOptional handle null/undefined
+          }
+          if (typeof value !== 'object' || Array.isArray(value)) {
+            return false;
+          }
+          const [maxLen] = args.constraints;
+          const record = value as Record<string, string>;
+          for (const val of Object.values(record)) {
+            if (typeof val !== 'string' || val.length > maxLen) {
+              return false;
+            }
+          }
+          return true;
+        },
+        defaultMessage(args: ValidationArguments) {
+          const [maxLen] = args.constraints;
+          return `Each value in ${args.property} must be a string with maximum length of ${maxLen} characters`;
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
- Truncate conversation titles to fit maximum length
- Update conversation creation to use truncated titles
- Introduce utility function for string truncation
- Increase max conversation title length constant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation titles and participant names are now automatically truncated to maintain optimal display length.

* **Improvements**
  * Maximum conversation title length increased from 50 to 150 characters.
  * Enhanced validation with clearer error messages for conversation participant data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---------